### PR TITLE
add deprecation tier

### DIFF
--- a/ISSUE_TEMPLATE/deprecated.md
+++ b/ISSUE_TEMPLATE/deprecated.md
@@ -1,0 +1,7 @@
+We believe this repository is Deprecated and therefore needs the following files updated:
+
+* [ ] [The Deprecated badge](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#deprecated-badge)
+* [ ] [The Deprecated Statement in the README.md](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#deprecated-statement)
+
+More details about the project life cycle tiers is available at [Equinix Labs: Uniform Standards](https://github.com/equinix-labs/equinix-labs/blob/main/uniform-standards.md)
+

--- a/ISSUE_TEMPLATE/end-of-life-issue.md
+++ b/ISSUE_TEMPLATE/end-of-life-issue.md
@@ -1,29 +1,8 @@
-Hello!
-
 We believe this repository is End of Life and therefore needs the following files updated:
 
 * [ ] [The End of Life badge](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#experimental-badge)
 * [ ] [The End of Life Statement in the README.md](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#experimental-statement)
 * [ ] Archive Status
 
-If you feel the repository should be maintained or experimental or that you'll need assistance to create these files, please let us know by filing an issue with <https://github.com/equinix-labs/equinix-labs>.
+More details about the project life cycle tiers is available at [Equinix Labs: Uniform Standards](https://github.com/equinix-labs/equinix-labs/blob/main/uniform-standards.md)
 
-Equinix Metal maintains a number of public repositories that help customers to run various workloads on Equinix Metal. These repositories are in various states of completeness and quality, and being public, developers often find them and start using them. This creates problems:
-
-* Developers using low-quality repositories may infer that Equinix Metal generally provides a low quality experience.
-* Many of our repositories are put online with no formal communication with, or training for, customer success. This leads to a below average support experience when things do go wrong.
-* We spend a huge amount of time supporting users through various channels when with better upfront planning, documentation and testing much of this support work could be eliminated.
-
-To that end, we propose four tiers of repositories: [Private](https://github.com/equinix-labs/equinix-labs#private-tier-minimum-requirements), [End of Life](https://github.com/equinix-labs/equinix-labs#end-of-life-tier-minimum-requirements), [Experimental](https://github.com/equinix-labs/equinix-labs#experimental-tier-minimum-requirements), and [Maintained](https://github.com/equinix-labs/equinix-labs#maintained-tier-minimum-requirements).
-
-As a resource and example of a maintained repository, we've created <https://github.com/equinix-labs/equinix-labs>. This is also where you can file any requests for assistance or modification of scope.
-
-### The Goal
-
-Our repositories should be the example from which adjacent, competing, projects look for inspiration.
-
-Each repository should not look entirely different from other repositories in the ecosystem, having a different layout, a different testing model, or a different logging model, for example, without reason or recommendation from the subject matter experts from the community.
-
-We should share our improvements with each ecosystem while seeking and respecting the feedback of these communities.
-
-Whether or not strict guidelines have been provided for the project type, our repositories should ensure that the same components are offered across the board. How these components are provided may vary, based on the conventions of the project type. GitHub provides general guidance on this which they have integrated into their user experience.

--- a/ISSUE_TEMPLATE/experimental-issue.md
+++ b/ISSUE_TEMPLATE/experimental-issue.md
@@ -1,5 +1,3 @@
-Hello!
-
 We believe this repository is Experimental and therefore needs the following files updated:
 
 * [ ] [The Experimental badge](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#experimental-badge)
@@ -12,23 +10,4 @@ We believe this repository is Experimental and therefore needs the following fil
 * [ ] [Developer Certificate of Origin](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#developer-certificate-of-origin)
 * [ ] At least one [maintainer](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#maintainer)
 
-If you feel the repository should be maintained or end of life or that you'll need assistance to create these files, please let us know by filing an issue with https://github.com/equinix-labs/equinix-labs.
-
-Equinix Metal maintains a number of public repositories that help customers to run various workloads on Equinix Metal. These repositories are in various states of completeness and quality, and being public, developers often find them and start using them. This creates problems:
-
-* Developers using low-quality repositories may infer that Equinix Metal generally provides a low quality experience.
-* Many of our repositories are put online with no formal communication with, or training for, customer success. This leads to a below average support experience when things do go wrong.
-* We spend a huge amount of time supporting users through various channels when with better upfront planning, documentation and testing much of this support work could be eliminated.
-
-To that end, we propose three tiers of repositories: [Private](https://github.com/equinix-labs/equinix-labs#private-tier-minimum-requirements), [Experimental](https://github.com/equinix-labs/equinix-labs#experimental-tier-minimum-requirements), and [Maintained](https://github.com/equinix-labs/equinix-labs#maintained-tier-minimum-requirements).
-
-As a resource and example of a maintained repository, we've created https://github.com/equinix-labs/equinix-labs. This is also where you can file any requests for assistance or modification of scope.
-
-### The Goal
-Our repositories should be the example from which adjacent, competing, projects look for inspiration.
-
-Each repository should not look entirely different from other repositories in the ecosystem, having a different layout, a different testing model, or a different logging model, for example, without reason or recommendation from the subject matter experts from the community.
-
-We should share our improvements with each ecosystem while seeking and respecting the feedback of these communities.
-
-Whether or not strict guidelines have been provided for the project type, our repositories should ensure that the same components are offered across the board. How these components are provided may vary, based on the conventions of the project type. GitHub provides general guidance on this which they have integrated into their user experience.
+More details about the project life cycle tiers is available at [Equinix Labs: Uniform Standards](https://github.com/equinix-labs/equinix-labs/blob/main/uniform-standards.md)

--- a/ISSUE_TEMPLATE/maintained-issue.md
+++ b/ISSUE_TEMPLATE/maintained-issue.md
@@ -1,5 +1,3 @@
-Hello!
-
 We believe this repository is Maintained and therefore needs the following files updated:
 
 * [ ] Flagged Public
@@ -18,26 +16,5 @@ We believe this repository is Maintained and therefore needs the following files
 * [ ] [SUPPORT.md](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#supportmd)
 * [ ] [RELEASE.md](https://github.com/equinix-labs/equinix-labs/blob/main/glossary.md#releasemd)
 
-If you feel the repository should be experimental or end of life or that you'll need assistance to update these files, please let us know by filing an issue with <https://github.com/equinix-labs/equinix-labs>.
+More details about the project life cycle tiers is available at [Equinix Labs: Uniform Standards](https://github.com/equinix-labs/equinix-labs/blob/main/uniform-standards.md)
 
-## The Uniform Standards Project
-
-Equinix Metal maintains a number of public repositories that help customers to run various workloads on Equinix Metal. These repositories are in various states of completeness and quality, and being public, developers often find them and start using them. This creates problems:
-
-* Developers using low-quality repositories may infer that Equinix Metal generally provides a low quality experience.
-* Many of our repositories are put online with no formal communication with, or training for, customer success. This leads to a below average support experience when things do go wrong.
-* We spend a huge amount of time supporting users through various channels when with better upfront planning, documentation and testing much of this support work could be eliminated.
-
-To that end, we propose three tiers of repositories: [Private](https://github.com/equinix-labs/equinix-labs#private-tier-minimum-requirements), [Experimental](https://github.com/equinix-labs/equinix-labs#experimental-tier-minimum-requirements), and [Maintained](https://github.com/equinix-labs/equinix-labs#maintained-tier-minimum-requirements).
-
-As a resource and example of a maintained repository, we've created <https://github.com/equinix-labs/equinix-labs>. This is also where you can file any requests for assistance or modification of scope.
-
-### The Goal
-
-Our repositories should be the example from which adjacent, competing, projects look for inspiration.
-
-Each repository should not look entirely different from other repositories in the ecosystem, having a different layout, a different testing model, or a different logging model, for example, without reason or recommendation from the subject matter experts from the community.
-
-We should share our improvements with each ecosystem while seeking and respecting the feedback of these communities.
-
-Whether or not strict guidelines have been provided for the project type, our repositories should ensure that the same components are offered across the board. How these components are provided may vary, based on the conventions of the project type. GitHub provides general guidance on this which they have integrated into their user experience.

--- a/deprecated.md
+++ b/deprecated.md
@@ -1,0 +1,13 @@
+# Deprecated Statements
+
+## Link Sentence
+This repository is [Deprecated](https://github.com/equinix-labs/equinix-labs/blob/main/deprecated.md)!
+
+## Short Statement
+This repository is Deprecated meaning that this software is only supported or maintained by Equinix Metal and its community in a case-by-case basis.
+
+## Extended Statement
+This repository is Deprecated meaning that this software is only supported or maintained by Equinix Metal and its community in a case-by-case basis.
+
+An alternative project or approach will generally be made available and documented in the project README.md.
+The project description and link in GitHub should be updated to "Deprecated: See <url>.", where URL is used in the GitHub project link and refers to the replacement project or deprecation note.

--- a/getting-started.md
+++ b/getting-started.md
@@ -11,6 +11,8 @@ In the `equinix-labs` repo we have a number of templates and resources that you 
 
 [Experimental](https://github.com/equinix-labs/equinix-labs/blob/main/ISSUE_TEMPLATE/experimental-issue.md) 
 
+[Deprecated](https://github.com/equinix-labs/equinix-labs/blob/main/ISSUE_TEMPLATE/deprecated-issue.md)
+
 [Maintained](https://github.com/equinix-labs/equinix-labs/blob/main/ISSUE_TEMPLATE/maintained-issue.md)
 
 [End of Life](https://github.com/equinix-labs/equinix-labs/blob/main/ISSUE_TEMPLATE/end-of-life-issue.md)

--- a/glossary.md
+++ b/glossary.md
@@ -24,6 +24,14 @@ Contributing notes may be included in README.md or in a separate CONTRIBUTING.md
 
 This repository is [End of Life](end-of-life-statement.md) meaning that this software is no longer supported nor maintained by Equinix Metal or its community.
 
+## Deprecated Badge
+
+[![Deprecated](https://img.shields.io/badge/Stability-Deprecated-black.svg)](deprecated-statement.md#deprecated-statements)
+
+## Deprecated Statement
+
+This repository is [Deprecated](deprecated-statement.md) meaning that this software is not recommended, improved, by Equinix Metal or its community. Maintaince will slow until the project reaches End of Life.
+
 ## Experimental Badge
 
 [![Experimental](https://img.shields.io/badge/Stability-Experimental-red.svg)](experimental-statement.md#experimental-statement)

--- a/uniform-standards.md
+++ b/uniform-standards.md
@@ -16,7 +16,12 @@ Equinix Metal maintains a number of public repositories that help customers to r
 * Many of our repositories are put online with no formal communication with, or training for, customer success. This leads to a below average support experience when things do go wrong.
 * We spend a huge amount of time supporting users through various channels when with better upfront planning, documentation and testing much of this support work could be eliminated.
 
-To that end, we propose four tiers of repositories: [Private](#private-tier-minimum-requirements), [End of Life](#end-of-life-tier-minimum-requirements), [Experimental](#experimental-tier-minimum-requirements), and [Maintained](#maintained-tier-minimum-requirements).
+To that end, we propose tiers of repositories:
+* [Private](#private-tier-minimum-requirements)
+* [End of Life](#end-of-life-tier-minimum-requirements)
+* [Deprecated](#deprecated-tier-minimum-requirements)
+* [Experimental](#experimental-tier-minimum-requirements)
+* [Maintained](#maintained-tier-minimum-requirements)
 
 ### The Goal
 
@@ -40,6 +45,10 @@ These repositories are not public at all, therefore, there are no minimum requir
 
 We no longer support nor maintain these projects. Our end of life project requirements are outlined in [the process](#the-process) below.
 
+### Deprecation Tier
+
+We no longer actively support nor maintain these projects. The project is not recommended for use in favor of alternatives. Our deprecation project requirements are outlined in [the process](#the-process) below.
+
 ### Experimental Tier
 
 Use at your own risk and do not expect thorough support!  Our experimental project requirements are outlined in [the process](#the-process) below.
@@ -52,5 +61,5 @@ We stand behind these repositories and support using them in production! Our mai
 
 1. A repository is reviewed by Equinix Metal and filed as Maintained, Experimental, or EndOfLife. _Private projects are exempt from this process._
 2. Maintained repositories may be moved to <https://github.com/equinix>. Experimental repositories may be moved to <https://github.com/equinix-labs>. End of Life repositories may remain where they are archived.
-3. An issue is filed on the repository using the [maintained issue template](ISSUE_TEMPLATE/maintained-issue.md) or the [Experimental Issue template](ISSUE_TEMPLATE/experimental-issue.md)  or the [End of Life Issue template](ISSUE_TEMPLATE/end-of-life-issue.md) which creates a checklist directly on the repository.
+3. An issue is filed on the repository using the issue template which creates a checklist directly on the respository (see [ISSUE_TEMPLATE/](ISSUE_TEMPLATE/)).
 4. Work is completed via pull requests.


### PR DESCRIPTION
fixes #77 by adding a Deprecation tier

Removes redundant ISSUE_TEMPLATE text that is best described centrally in the uniform-standards.md doc.