### PR TITLE
Add provider meta module_name in Equinix Metal TF configs

### DIFF
--- a/terraform-module-standards.md
+++ b/terraform-module-standards.md
@@ -328,11 +328,11 @@ Publishing outputs with remote states:
 
 ### Terraform
 
-Terraform v0.12 is a significant release that includes some backwards incompatibilities and significant changes with each new version. Once a Terraform config has been upgraded to Terraform 0.12, it should be pinned to the latest release it has been tested with.
+Terraform v0.13.0 is recommended that any module taking advantage of Provider Metadata functionality should specify a minimum Terraform version of 0.13.0 or higher.
 
 ```hcl
 terraform {
-  required_version = "~> 0.12.16"
+  required_version = "~> 0.13.0"
 }
 ```
 
@@ -345,7 +345,7 @@ You should make updating the version pin a regular practice:
 ```hcl
 provider "equinix" {
   source = "equinix/equinix"
-  version = "= 1.11.0-alpha.2"
+  version = "= 1.11.0"
 }
 ```
 
@@ -353,6 +353,11 @@ In shared modules, the provider version should **not** be pinned. Instead, a [ve
 
 ```hcl
 terraform { 
+  provider_meta "equinix" {
+    # Set the name of the module below 
+    module_name = "equinix-labs"
+  }
+
   required_providers { 
     equinix = {
         source = "equinix/equinix"


### PR DESCRIPTION
What this PR does / why we need it:
It allows Vendor to declare the metadata fields.  It adds  provider meta module_name in Equinix Metal TF configs


Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):

Related to https://github.com/equinix/terraform-provider-equinix/issues/252